### PR TITLE
Add new pending meetings at their correct positions

### DIFF
--- a/coffeepod/webapp/css/hub-ind.css
+++ b/coffeepod/webapp/css/hub-ind.css
@@ -451,3 +451,7 @@ input:focus, textarea:focus {
     font-style: italic;
     padding-left: 14px;
 }
+
+#meeting-new-entry{
+    color: #AA6231;
+}

--- a/coffeepod/webapp/hub-ind.html
+++ b/coffeepod/webapp/hub-ind.html
@@ -307,7 +307,7 @@
                             <p class="tab-title">Upcoming meetings</p>
                             <p class="mb-0">You have <span id="num-upcoming"> </span> upcoming meeting(s).</p>
                             <ol class="hidden meeting-list" id="upcoming-meeting-list">
-                              <li class="hidden" id="meeting-ele"> <a id="meeting-date">Tuesday, July 18, 2020</a></li>
+                              <li class="hidden" id="meeting-ele"> <span class="hidden" id="meeting-new-entry">(NEW!)</span> <a id="meeting-date">Tuesday, July 18, 2020</a></li>
                             </ol>
                           </div>
                           <div id="pending-meetings" class="container tab-pane fade"><br>

--- a/coffeepod/webapp/js/meetings.js
+++ b/coffeepod/webapp/js/meetings.js
@@ -2,6 +2,7 @@
 // When accepted = false and pending = true, then we are waiting for the other person's response
 // When accepted = true and pending = false, the meeting has been accepted and should be added to the schedule
 
+let pendingMeetings = [];
 
 class Meeting {
      constructor(id, title, when, where, description, pending, accepted) {
@@ -62,11 +63,86 @@ function recordMeetingInfoAndSendNotification(meeting) {
         meeting.id = newMeetingRef.id;;
         sendMeetingNotification(meeting);
 
+        console.log("the current pending meetings are: " + pendingMeetings);
         // Reflect the change in the dom (add the meeting to pending section without refreshing)
-        addMeetingToList("pending-meeting-list", meeting.id, new Date(meeting.when));
+        insertNewPendingMeeting(meeting);
+        /*
+        if (pendingMeetings.length == 0) {
+            addMeetingToList("pending-meeting-list", meeting.id, new Date(meeting.when), false, true);
+        } else { 
+            console.log("more than 0 pending meetings so far!");
+            insertNewPendingMeeting(meeting);
+        }*/
+
+        // After adding new meeting, push this meeting to pendingMeetings 
+        // Should already push in get prior index element
         document.getElementById("num-pending").innerText = parseInt(document.getElementById("num-pending").innerText) + 1;
     })
 }
+
+function insertNewPendingMeeting(newPendingMeeting) {
+    
+    const priorElementIndex = getPriorElementIndex(newPendingMeeting);
+
+    if (priorElementIndex == -1) {
+        addMeetingToList("pending-meeting-list", newPendingMeeting.id, new Date(newPendingMeeting.when), false, true);
+        return;
+    } 
+
+    console.log("a prior element exists");
+    const priorElementId = pendingMeetings[priorElementIndex].id;
+
+    console.log("priorElementId is: " + priorElementId);
+   // Insertion part
+    const priorElement = document.getElementById(priorElementId);
+    
+    // Create a new li element
+    const newPendingMeetingEle = document.getElementById("meeting-ele").cloneNode("true");
+    newPendingMeetingEle.setAttribute('id', newPendingMeeting.id);
+
+    // Set the content of the new li element
+    const meetingDate = newPendingMeetingEle.querySelector("#meeting-date");
+    meetingDate.innerText = new Date(newPendingMeeting.when);
+    const isPastMeeting = false;
+    console.log("isPastMeeting is: " + isPastMeeting);
+    meetingDate.setAttribute('onclick', 'showMeetingDetails(' + "'" + newPendingMeeting.id + "'" + "," + "'" + isPastMeeting + "'" + "," + "'" + "pending-meeting-list" + "'" + ')');
+
+    newPendingMeetingEle.querySelector("#meeting-new-entry").classList.remove('hidden');
+
+    // Add it to its correct position
+    priorElement.parentNode.insertBefore(newPendingMeetingEle, priorElement.nextSibling);
+    // Show it to the user 
+    newPendingMeetingEle.classList.remove("hidden");
+}
+
+// Return prior element id rather than the index in pendingMeetings that the element needs to be placed
+// This is because the prior element id is needed for insertion later into the DOM 
+// newPending meeting is a meeting object, and pendingMeetings is an array of meeting objects
+
+function getPriorElementIndex (newPendingMeeting) {
+    let low = 0, high = pendingMeetings.length - 1;
+    let mid = parseInt((low+high)/2);
+
+    while (low <= high) {
+        if (newPendingMeeting.when < pendingMeetings[mid].when) {
+            high = mid - 1;
+        } else if (newPendingMeeting.when > pendingMeetings[mid].when) {
+            low = mid + 1;
+        } else { //If there is a time exactly like the new pending meeting
+            pendingMeetings.splice(mid, 0, newPendingMeeting);
+            return mid - 1;
+        }
+        mid = parseInt((low + high)/2);
+    }
+    // Exit the loop when low == high
+    // Add the pending meeting into pending meetings as the user maybe adding many meetings at the same time (edge case)
+    
+
+    pendingMeetings.splice(low, 0, newPendingMeeting);
+
+    return low - 1;
+}
+
 
 function sendMeetingNotification(meeting) {
     db.collection('mentorship').doc(mentorshipID).get().then(function(mentorship) {
@@ -89,7 +165,7 @@ function getAcceptedMeetings() {
     meetingsRef.where('when', '>', Date.now()).where('accepted', '==', true).orderBy("when", "asc").get().then(function (meetings) {
         meetings.forEach(meeting => {
             meetingCount += 1;
-            addMeetingToList("upcoming-meeting-list", meeting.id, meeting.data().when, false);
+            addMeetingToList("upcoming-meeting-list", meeting.id, meeting.data().when, false, false);
         });
             document.getElementById("num-upcoming").innerText = meetingCount;
             document.getElementById("upcoming-meeting-list").classList.remove('hidden');
@@ -102,7 +178,13 @@ function getPendingMeetings() {
     meetingsRef.where('when', '>', Date.now()).where('pending', '==', true).orderBy("when", "asc").get().then(function (meetings) {
         meetings.forEach(meeting => {
             meetingCount += 1;
-            addMeetingToList("pending-meeting-list", meeting.id, meeting.data().when, false);
+
+            // add meeting objects to pending meeting
+            const data = meeting.data();
+            let meetingJS = new Meeting(meeting.id, data.title, data.when, data.where, data.description, data.pending, data.accepted);
+            pendingMeetings.push(meetingJS);
+
+            addMeetingToList("pending-meeting-list", meeting.id, meeting.data().when, false, false);
         });
             document.getElementById("num-pending").innerText = meetingCount;
             document.getElementById("pending-meeting-list").classList.remove('hidden');
@@ -115,7 +197,7 @@ function getPastMeetings() {
     meetingsRef.where('when', '<=', Date.now()).where('pending', '==', false).where('accepted', '==', true).orderBy("when", "asc").get().then(function (meetings) {
         meetings.forEach(meeting => {
             meetingCount += 1;
-            addMeetingToList("past-meeting-list", meeting.id, meeting.data().when, true);
+            addMeetingToList("past-meeting-list", meeting.id, meeting.data().when, true, false);
         });
         document.getElementById("num-past").innerText = meetingCount;
         document.getElementById("past-meeting-list").classList.remove('hidden');
@@ -123,11 +205,21 @@ function getPastMeetings() {
 }
 
 
-function addMeetingToList(listId, meetingId, meetingWhen, isPastMeeting){
+// first child is only used for pending meeting elements that needed to be added to the front of a list
+function addMeetingToList(listId, meetingId, meetingWhen, isPastMeeting, firstChild){
     const meetingList = document.getElementById(listId);
 
     const meetingLiEle = document.getElementById("meeting-ele")
     const meetingLiEleCloned = meetingLiEle.cloneNode(true);
+
+    if (firstChild == true) {
+        console.log(meetingList.innerHTML);
+        console.log("i'm in the firstChild part");
+        meetingList.insertBefore(meetingLiEleCloned, meetingList.childNodes[0]);
+        meetingLiEleCloned.querySelector("#meeting-new-entry").classList.remove('hidden');
+    } else {
+        meetingList.appendChild(meetingLiEleCloned);
+    }
 
     meetingLiEleCloned.setAttribute('id', meetingId);
     meetingLiEleCloned.classList.remove('hidden');
@@ -135,8 +227,6 @@ function addMeetingToList(listId, meetingId, meetingWhen, isPastMeeting){
     const meetingDate = meetingLiEleCloned.querySelector("#meeting-date");
     meetingDate.innerText = new Date(meetingWhen);
     meetingDate.setAttribute('onclick', 'showMeetingDetails(' + "'" + meetingId + "'" + "," + "'" + isPastMeeting + "'" + "," + "'" + listId + "'" + ')');
-
-    meetingList.appendChild(meetingLiEleCloned);
 }
 
 function showMeetingDetails(meetingId, isPastMeeting, listId) {
@@ -227,6 +317,12 @@ function deleteMeeting(meetingId, listId) {
     document.getElementById(meetingId).classList.add('hidden');
     updateNumberOfMeetingsInSection(listId);
 
+    // Delete meeting element from pending meetings
+    if (listId.includes("pending")) {
+        // Only keep meetings that are not deleted!
+        pendingMeetings = pendingMeetings.filter(pendingMeeting => pendingMeeting.id != meetingId);
+    }
+
     const meetingRef = db.collection('mentorship').doc(mentorshipID).collection('meetings').doc(meetingId);
     meetingRef.get().then(function(meeting) {
         //deleteMeetingFromFirestore(meetingId);
@@ -293,4 +389,3 @@ function removeMeetingRequestForOneUser(meetingId, userId) {
 function deleteMeetingFromFirestore(meetingId) {
     db.collection('mentorship').doc(mentorshipID).collection('meetings').doc(meetingId).delete();
 }
-

--- a/coffeepod/webapp/js/meetings.js
+++ b/coffeepod/webapp/js/meetings.js
@@ -108,6 +108,9 @@ function insertNewPendingMeeting(newPendingMeeting) {
 // This is because the prior element id is needed for insertion later into the DOM 
 // newPending meeting is a meeting object, and pendingMeetings is an array of meeting objects
 
+// The reason to get the prior index element is because adding the new pending meeting to the meeting list here is convenient
+// The index is readily available for slice method
+
 function getPriorElementIndex (newPendingMeeting) {
     let low = 0, high = pendingMeetings.length - 1;
     let mid = parseInt((low+high)/2);

--- a/coffeepod/webapp/js/meetings.js
+++ b/coffeepod/webapp/js/meetings.js
@@ -63,16 +63,8 @@ function recordMeetingInfoAndSendNotification(meeting) {
         meeting.id = newMeetingRef.id;;
         sendMeetingNotification(meeting);
 
-        console.log("the current pending meetings are: " + pendingMeetings);
         // Reflect the change in the dom (add the meeting to pending section without refreshing)
         insertNewPendingMeeting(meeting);
-        /*
-        if (pendingMeetings.length == 0) {
-            addMeetingToList("pending-meeting-list", meeting.id, new Date(meeting.when), false, true);
-        } else { 
-            console.log("more than 0 pending meetings so far!");
-            insertNewPendingMeeting(meeting);
-        }*/
 
         // After adding new meeting, push this meeting to pendingMeetings 
         // Should already push in get prior index element
@@ -89,10 +81,8 @@ function insertNewPendingMeeting(newPendingMeeting) {
         return;
     } 
 
-    console.log("a prior element exists");
     const priorElementId = pendingMeetings[priorElementIndex].id;
 
-    console.log("priorElementId is: " + priorElementId);
    // Insertion part
     const priorElement = document.getElementById(priorElementId);
     
@@ -104,7 +94,6 @@ function insertNewPendingMeeting(newPendingMeeting) {
     const meetingDate = newPendingMeetingEle.querySelector("#meeting-date");
     meetingDate.innerText = new Date(newPendingMeeting.when);
     const isPastMeeting = false;
-    console.log("isPastMeeting is: " + isPastMeeting);
     meetingDate.setAttribute('onclick', 'showMeetingDetails(' + "'" + newPendingMeeting.id + "'" + "," + "'" + isPastMeeting + "'" + "," + "'" + "pending-meeting-list" + "'" + ')');
 
     newPendingMeetingEle.querySelector("#meeting-new-entry").classList.remove('hidden');
@@ -213,8 +202,6 @@ function addMeetingToList(listId, meetingId, meetingWhen, isPastMeeting, firstCh
     const meetingLiEleCloned = meetingLiEle.cloneNode(true);
 
     if (firstChild == true) {
-        console.log(meetingList.innerHTML);
-        console.log("i'm in the firstChild part");
         meetingList.insertBefore(meetingLiEleCloned, meetingList.childNodes[0]);
         meetingLiEleCloned.querySelector("#meeting-new-entry").classList.remove('hidden');
     } else {


### PR DESCRIPTION
Add new pending meetings at their correct positions in the current pending meeting list shown rather than just adding that newly created meeting at the end of the list. Also add an indicator to show that the meeting has just been created (!NEW at the start of a li element).